### PR TITLE
chore: pin eslint to 8

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,6 +8,10 @@
       "matchDatasources": ["npm"],
       "automerge": true,
       "automergeType": "pr"
+    },
+    {
+      "matchPackageNames": ["eslint"],
+      "allowedVersions": "^8.0.0"
     }
   ],
   "lockFileMaintenance": {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated dependency management settings to restrict "eslint" updates to versions matching ^8.0.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->